### PR TITLE
Add RightDao search engine

### DIFF
--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -924,6 +924,15 @@ engines:
     timeout : 10.0
     disabled : True
 
+  - name : rightdao
+    shortcut: rdo
+    engine: xpath
+    paging : True
+    search_url : https://rightdao.com/search?q={query}
+    url_xpath : //div[@class="info"]/span[@class="url"]
+    title_xpath : //div[@class="title"]/a/div[@class="ellipsis-lg"]
+    content_xpath : //div[@class="description"]
+
 # tmp suspended: bad certificate
 #  - name : scanr structures
 #    shortcut: scs


### PR DESCRIPTION
Add the RightDao search engine to settings.yml

## What does this PR do?

Adds RightDao search engine to settings.yml.

## Why is this change important?

Adding additional search choices to Searx.  This is a fairly new general search engine with its own independent database and claims a no-tracking policy.

## How to test this PR locally?

## Author's checklist

Passes both make run and make test.pylint

I've been successfully including RightDao search results with no errors for several days with this code added to my own Searx instance.

## Related issues

<!--
Closes #234
-->
